### PR TITLE
Update SeasonStatusEffects.cs

### DIFF
--- a/Seasonality/Seasons/SeasonStatusEffects.cs
+++ b/Seasonality/Seasons/SeasonStatusEffects.cs
@@ -392,7 +392,7 @@ public class SeasonEffect : StatusEffect
     public override void ModifyFallDamage(float baseDamage, ref float damage)
     {
         if (m_character.m_seman.m_statusEffects.Exists(x => x.m_name == "$se_slowfall_name")) return;
-        damage = baseDamage * data.Modifiers[Modifier.FallDamage];
+        damage = damage * data.Modifiers[Modifier.FallDamage];
         if (damage >= 0.0) return;
         damage = 0.0f;
     }


### PR DESCRIPTION
ModifyFallDamage: use ref damage as start for calculation instead of baseDamage, otherwise changes of other status effects are overwritten.